### PR TITLE
Replace font noncompliant characters

### DIFF
--- a/ChatTranslator.cs
+++ b/ChatTranslator.cs
@@ -29,6 +29,7 @@ namespace ChatTranslator
         private Lumina.Excel.ExcelSheet<UIColor> _uiColours;
         private bool _notSelf;
         private bool _whitelist;
+        private bool _replaceUnprintable;
         private List<string> _blacklist;
         private List<int> _chosenLanguages;
         private List<XivChatType> _channels = new List<XivChatType>();
@@ -232,5 +233,6 @@ namespace ChatTranslator
         public int OneInt { get; set; }
         public List<string> Blacklist { get; set; } = new List<string>();
         public int TranMode { get; set; }
+        public bool ReplaceUnprintable { get; set; }
     }
 }

--- a/ChatTranslator.cs
+++ b/ChatTranslator.cs
@@ -30,6 +30,7 @@ namespace ChatTranslator
         private bool _notSelf;
         private bool _whitelist;
         private bool _replaceUnprintable;
+        private bool _removeDiacritics;
         private List<string> _blacklist;
         private List<int> _chosenLanguages;
         private List<XivChatType> _channels = new List<XivChatType>();
@@ -234,5 +235,6 @@ namespace ChatTranslator
         public List<string> Blacklist { get; set; } = new List<string>();
         public int TranMode { get; set; }
         public bool ReplaceUnprintable { get; set; }
+        public bool RemoveDiacritics { get; set; }
     }
 }

--- a/Handy.cs
+++ b/Handy.cs
@@ -19,6 +19,7 @@ namespace ChatTranslator
             _configuration.TextColour = _textColour;
             _configuration.Blacklist = _blacklist;
             _configuration.TranMode = _tranMode;
+            _configuration.ReplaceUnprintable = _replaceUnprintable;
             _pluginInterface.SavePluginConfig(_configuration);
         }
 

--- a/Handy.cs
+++ b/Handy.cs
@@ -20,6 +20,7 @@ namespace ChatTranslator
             _configuration.Blacklist = _blacklist;
             _configuration.TranMode = _tranMode;
             _configuration.ReplaceUnprintable = _replaceUnprintable;
+            _configuration.RemoveDiacritics = _removeDiacritics;
             _pluginInterface.SavePluginConfig(_configuration);
         }
 

--- a/Translater.cs
+++ b/Translater.cs
@@ -31,6 +31,21 @@ namespace ChatTranslator
             }
         }
 
+        // Obviously not a non exhaustive list, this mainly deals with unprintable characters when translating to Romanian
+        public static readonly Dictionary<char, char> UnprintableReplacement = new Dictionary<char, char>
+        {
+            {'Ă', 'A'},
+            {'ă', 'a'},
+            {'Ș', 's'},
+            {'ș', 's'},
+            {'Ț', 'T'},
+            {'ț', 't'},
+            {'Ē', 'E'},
+            {'ē', 'e'},
+            {'Č', 'C'},
+            {'č', 'c'}
+        };
+
         private static string Lang(string message)
         {
             var languages = Identifier.Identify(message);
@@ -102,6 +117,12 @@ namespace ChatTranslator
                 var text = (TextPayload)messageSeString.Payloads[i];
                 var translatedText = Translate(text.Text);
                 if (translatedText == "LOOP") continue;
+                //Check if unprintable characters should be replaced
+                if (_replaceUnprintable)
+                {
+                    translatedText = string.Join("", translatedText
+                        .Select(c => UnprintableReplacement.ContainsKey(c) ? UnprintableReplacement[c] : c));
+                }
                 messageSeString.Payloads[i] = new TextPayload(translatedText);
                 messageSeString.Payloads.Insert(i, new UIForegroundPayload(_pluginInterface.Data, (ushort)_textColour[0].Option));
                 messageSeString.Payloads.Insert(i, new UIForegroundPayload(_pluginInterface.Data, 0));

--- a/UI.cs
+++ b/UI.cs
@@ -59,6 +59,12 @@ namespace ChatTranslator
                                 SaveConfig();
                             }
                         }
+
+                        ImGui.Checkbox("Replace unprintable characters", ref _replaceUnprintable);
+                        ImGui.SameLine();
+                        ImGui.Text("(?)"); if (ImGui.IsItemHovered()) { ImGui.SetTooltip("Replaces characters that would otherwise" +
+                                                                                                "\nshow up as \"=\" in chat with accentless" +
+                                                                                                "\nor best/closest chat-printable matches.");}
                         
                         ImGui.EndTabItem();
                     }

--- a/UI.cs
+++ b/UI.cs
@@ -65,7 +65,14 @@ namespace ChatTranslator
                         ImGui.Text("(?)"); if (ImGui.IsItemHovered()) { ImGui.SetTooltip("Replaces characters that would otherwise" +
                                                                                                 "\nshow up as \"=\" in chat with accentless" +
                                                                                                 "\nor best/closest chat-printable matches.");}
-                        
+
+                        if (_replaceUnprintable)
+                        {
+                            ImGui.Checkbox("Remove all diacritics from translations", ref _removeDiacritics);
+                            ImGui.SameLine();
+                            ImGui.Text("(?)"); if (ImGui.IsItemHovered()) { ImGui.SetTooltip("Strip translation of all diacritics regardless" +
+                                                                                                     "\nof whether they can be displayed or not.");}
+                        }
                         ImGui.EndTabItem();
                     }
                     


### PR DESCRIPTION
A simple (non-exhaustive) dictionary match/replace logic bit to make translated characters that would otherwise show up as "=" in chat appear accentless (or match them to another accentuated character altogether) + a method to strip translated messages of any diacritics regardless of whether they render properly or not.